### PR TITLE
Sprint.2.12. Add video recording for failed tests for both local and CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run tests
         run: mvn test
         env:
-          BROWSER_OPTIONS: browser=chromium;width=1920;height=1080;headless=true;slowMo=0
+          BROWSER_OPTIONS: browser=chromium;width=1920;height=1080;headless=true;slowMo=0;tracing=true;video=true
           WEB_OPTIONS: username=${{ secrets.USERNAME }};password=${{ secrets.PASSWORD }};base_url=${{ secrets.BASE_URL}}
           CI_RUN: true
 
@@ -40,9 +40,11 @@ jobs:
           path: target/surefire-reports/TEST-*.xml
           reporter: java-junit
 
-      - name: Attach test trace
+      - name: Attach artifacts on failure
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: testTracing
-          path: testTracing/
+          name: Artifacts
+          path: |
+            testTracing/
+            videos/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 testTracing/
+videos/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/

--- a/src/test/java/utils/ProjectProperties.java
+++ b/src/test/java/utils/ProjectProperties.java
@@ -20,6 +20,8 @@ public class ProjectProperties {
     public static final double IS_SLOW = Double.parseDouble(properties.getProperty("slowMo").trim());
     public static final int SCREEN_SIZE_WIDTH = Integer.parseInt(properties.getProperty("width").trim());
     public static final int SCREEN_SIZE_HEIGHT = Integer.parseInt(properties.getProperty("height").trim());
+    public static final boolean TRACING_MODE = Boolean.parseBoolean(properties.getProperty("tracing").trim());
+    public static final boolean VIDEO_MODE = Boolean.parseBoolean(properties.getProperty("video").trim());
     public static final String USERNAME = properties.getProperty("username").trim();
     public static final String PASSWORD = properties.getProperty("password").trim();
 

--- a/src/test/java/utils/ReportUtils.java
+++ b/src/test/java/utils/ReportUtils.java
@@ -2,6 +2,7 @@ package utils;
 
 import org.testng.ITestContext;
 import org.testng.ITestResult;
+import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
 import java.text.SimpleDateFormat;
@@ -21,8 +22,8 @@ public class ReportUtils {
         return dateFormat.format(date);
     }
 
-    private static String getTestStatus(ITestResult result) {
-        int status = result.getStatus();
+    private static String getTestStatus(ITestResult testResult) {
+        int status = testResult.getStatus();
 
         return switch (status) {
             case 1 -> "PASS";
@@ -32,8 +33,8 @@ public class ReportUtils {
         };
     }
 
-    private static String getTestRunTime(ITestResult result) {
-        final long time = result.getEndMillis() - result.getStartMillis();
+    private static String getTestRunTime(ITestResult testResult) {
+        final long time = testResult.getEndMillis() - testResult.getStartMillis();
         int minutes = (int) ((time / 1000) / 60);
         int seconds = (int) (time / 1000) % 60;
         int milliseconds = (int) (time % 1000);
@@ -41,23 +42,27 @@ public class ReportUtils {
         return minutes + " min " + seconds + " sec " + milliseconds + " ms";
     }
 
-    public static String getReportHeader(ITestContext context) {
+    public static String getReportHeader(ITestContext testContext) {
         String header = "\tT E S T     R E P O R T\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t" + "\n";
         String currentDate = "\tDate:" + getCurrentDateTime() + "\t\t\t\t\t\t\t\t\t\t\t\t\t\t" + "\n";
 
         return "\n" + H_LINE + header + currentDate + H_LINE;
     }
 
-    public static String getClassNameTestName(Method method, ITestResult result) {
-        String className = result.getTestClass().toString();
-        String testName = method.getName();
-
-        return className.substring(22, className.length() - 1) + "/" + testName;
+    public static String getTestStatistics(Method method, ITestResult testResult) {
+        return "\n\n" + getTestMethodNameWithInvocationCount(method, testResult)
+                + "   ----   " + getTestStatus(testResult) + "\t Run Time: " + getTestRunTime(testResult) + "\n";
     }
 
-    public static String getTestStatistics(Method method, ITestResult result) {
+    public static String getTestMethodName(Method method) {
+        return method.getDeclaringClass().getName() + "." + method.getName();
+    }
 
-        return "\n\n" + getClassNameTestName(method, result)
-                + "   ----   " + getTestStatus(result) + "\t Run Time: " + getTestRunTime(result) + "\n";
+    public static String getTestMethodNameWithInvocationCount(Method method, ITestResult testResult) {
+        String testMethodName = getTestMethodName(method);
+        if (!method.getAnnotation(Test.class).dataProvider().isEmpty()) {
+            testMethodName += "(" + testResult.getMethod().getCurrentInvocationCount() + ")";
+        }
+        return testMethodName;
     }
 }

--- a/src/test/resources/config.properties.TEMPLATE
+++ b/src/test/resources/config.properties.TEMPLATE
@@ -6,3 +6,5 @@ headless=false
 slowMo=1500
 width=1920
 height=1080
+tracing=true
+video=true


### PR DESCRIPTION
- Add video recording for failed tests for both local and CI runs;
- The mechanism for enabling and disabling of tracing and video recording is implemented in the config.properties and ci.yml;
- Add 'videos' folder to .gitignore.